### PR TITLE
Add "and" to the list of keywords

### DIFF
--- a/example/sample.s
+++ b/example/sample.s
@@ -1,0 +1,37 @@
+# Example dervied from the CPSC 213 Companion, Appendix C
+
+.pos 0x100
+  ld $0x1000, r1
+  ld $a, r1
+  ld $arr, r1
+  ld 4(r2), r3
+  ld (r1, r2, 4), r3
+  st r1, 8(r3)
+  st r1, (r2, r3, 4)
+  halt
+  nop
+  mov r1, r2
+  add r1, r2
+  and r1, r2
+  inc r1
+  inca r1
+  dec r1
+  deca r1
+  not r1
+  shl $2, r1
+  shr $2, r1
+  br 0x1008
+  beq r1, 0x1008
+  bgt r1, 0x1008
+  j 0x1000
+  gpc $6, r1
+  j 8(r1)
+  j *8(r1)
+  j *(r1, r2, 4)
+
+.pos 0x1000
+a:    .long 0xffffffff # a
+
+.pos 0x2000
+arr:    .long 0xffffffff # arr[0]
+        .long 0x00000000 # arr[1]

--- a/syntaxes/asm.tmLanguage.json
+++ b/syntaxes/asm.tmLanguage.json
@@ -27,7 +27,7 @@
                 },
                 {
                     "name": "keyword.instruction.asm",
-                    "match": "(ld|st|halt|nop|mov|add|inc|inca|dec|deca|not|shl|shr|br|beq|bgt|j|gpc)\\s"
+                    "match": "(ld|st|halt|nop|mov|add|and|inc|inca|dec|deca|not|shl|shr|br|beq|bgt|j|gpc)\\s"
                 }
             ]
         },


### PR DESCRIPTION
I noticed "and" was showing up without the keyword coloring, and indeed it was missing from the list; I added it here.

I also create a file, `examples/sample.s` to preview all of the common commands as a kind of "sanity check" everything is working as expected. It's not comprehensive (yet), but as a start I copied all the instructions listed in Appendix C of the course companion.